### PR TITLE
Add git-aware PowerShell prompt

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -106,6 +106,13 @@ sudo notepad C:\Windows\System32\drivers\etc\hosts
 C:\Work\code\devenv (master) > git push
 ```
 
+PowerShell 下同样支持，分支名的红/绿含义一致。采用两行布局，第一行显示「仓库相对路径 + 分支」，第二行输入命令，这样无论路径或分支名多长，光标都从最左侧开始：
+
+```console
+devenv  (master)
+> git push
+```
+
 ## 安装
 
 ```console

--- a/windows/install.bat
+++ b/windows/install.bat
@@ -1,1 +1,5 @@
 reg add "HKCU\Software\Microsoft\Command Processor" /v Autorun /d "%~dp0autorun.bat" /f
+
+echo Install PowerShell prompt
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0powershell\install.ps1"
+where pwsh >nul 2>nul && pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0powershell\install.ps1"

--- a/windows/powershell/install.ps1
+++ b/windows/powershell/install.ps1
@@ -1,0 +1,20 @@
+# Make the current user's PowerShell profile load the devenv git prompt.
+# Run once per PowerShell flavour (Windows PowerShell 5.1 and/or PowerShell 7),
+# because each one uses a different $PROFILE path. The change is idempotent.
+
+$promptScript = Join-Path $PSScriptRoot 'prompt.ps1'
+$sourceLine = ". '$promptScript'"
+
+$profilePath = $PROFILE.CurrentUserCurrentHost
+$profileDir = Split-Path $profilePath -Parent
+if (-not (Test-Path $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+}
+
+$existing = if (Test-Path $profilePath) { Get-Content $profilePath -Raw } else { '' }
+if ($existing -match [regex]::Escape($promptScript)) {
+    Write-Host "devenv prompt already installed in $profilePath"
+} else {
+    Add-Content -Path $profilePath -Value "`n# devenv: git-aware prompt`n$sourceLine"
+    Write-Host "Added devenv prompt to $profilePath"
+}

--- a/windows/powershell/prompt.ps1
+++ b/windows/powershell/prompt.ps1
@@ -1,0 +1,40 @@
+# Show the current git branch in the PowerShell prompt, mirroring the
+# Command Prompt version (see windows/git/update-prompt.cmd).
+#
+#   - Green branch name : clean working tree
+#   - Red branch name   : uncommitted changes
+#   - Two-line layout    : the typing column stays fixed no matter how long
+#                          the path or branch name is.
+#
+# Inside a repository only the repo-relative path is shown to keep the line
+# short; elsewhere the home directory is abbreviated to ~.
+
+function prompt {
+    $cwd = $ExecutionContext.SessionState.Path.CurrentLocation.Path
+
+    # A single git call yields both the branch and the repository root.
+    $info = @(git rev-parse --abbrev-ref HEAD --show-toplevel 2>$null)
+    if ($info.Count -ge 2) {
+        $branch = $info[0]
+        $top = $info[1] -replace '/', '\'
+        $repo = Split-Path $top -Leaf
+        if ($cwd.Length -gt $top.Length -and $cwd.Substring(0, $top.Length).ToLower() -eq $top.ToLower()) {
+            $display = "$repo$($cwd.Substring($top.Length))"
+        } else {
+            $display = $repo
+        }
+
+        # Lightweight dirty check: one diff, no file enumeration.
+        git diff --quiet 2>$null
+        $color = if ($LASTEXITCODE -eq 0) { 'Green' } else { 'Red' }
+
+        Write-Host $display -NoNewline -ForegroundColor DarkCyan
+        Write-Host "  ($branch)" -NoNewline -ForegroundColor $color
+        Write-Host ''
+    } else {
+        $p = $cwd
+        if ($p.ToLower().StartsWith($HOME.ToLower())) { $p = '~' + $p.Substring($HOME.Length) }
+        Write-Host $p -ForegroundColor DarkCyan
+    }
+    return '> '
+}


### PR DESCRIPTION
## 动机

仓库目前只在**命令提示符 (CMD)** 下显示 git 分支(`windows/git/update-prompt.cmd`,README「Git 增强」一节),PowerShell 下没有对应能力。本 PR 补上 PowerShell 版本。

## 改动

- **`windows/powershell/prompt.ps1`** — 定义 `prompt` 函数:
  - 显示当前分支名,**干净=绿色,有未提交改动=红色**,语义与 CMD 版一致(同样基于轻量的 `git diff --quiet`,不做文件枚举,对大仓库友好)。
  - **两行布局**:第一行「仓库相对路径 + 分支」,第二行输入命令,光标列固定,分支再长也不挤。
  - 仓库内只显示相对路径,仓库外把 home 缩写成 `~`。
  - 每次刷新仅 2 次 git 调用(`rev-parse` 合并取分支+根 + 一次 `diff --quiet`)。
- **`windows/powershell/install.ps1`** — 幂等地把 profile 接到 `prompt.ps1`,自动建 profile 目录。
- **`windows/install.bat`** — 接入安装流程,同时为 Windows PowerShell 5.1 和 PowerShell 7(检测到 `pwsh` 时)安装。
- **`windows/README.md`** — 在「Git 增强」一节补充 PowerShell 说明。

## 效果

```console
devenv  (master)      # 分支绿色=干净 / 红色=有改动
> git push
```

## 测试

在干净子进程中验证了仓库根、子目录、非 git 目录,以及脏/净着色,均与 ground truth 一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)