### PR TITLE
Add PowerShell path_manager (Add-Path / Remove-Path / Get-Path)

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -113,6 +113,21 @@ devenv  (master)
 > git push
 ```
 
+### PowerShell 路径变量管理
+
+`shell/path_manager` 的 PowerShell 版，管理 `PATH` 这类以 `;` 分隔的路径变量，去重后追加/前置：
+
+```powershell
+Add-PathVar C:\tools                 # 追加到 PATH（默认变量），仅当前会话（默认 Process）
+Add-PathVar C:\tools -Prepend        # 放到最前
+Add-PathVar C:\tools -Scope User     # 持久化到用户级，并同步到当前会话
+Add-PathVar D:\lib -Name LIB -Scope Machine   # 系统级（需管理员）
+Remove-PathVar C:\tools              # 移除
+```
+
+- 默认变量为 `PATH`，默认作用域为 `Process`（只影响当前交互）。
+- 已存在的路径会**提示并忽略**（大小写、结尾斜杠不敏感）。
+
 ## 安装
 
 ```console

--- a/windows/README.md
+++ b/windows/README.md
@@ -118,18 +118,18 @@ devenv  (master)
 `shell/path_manager` 的 PowerShell 版，管理 `PATH` 这类以 `;` 分隔的路径变量，去重后追加/前置：
 
 ```powershell
-Add-PathVar C:\tools                 # 追加到 PATH（默认变量），仅当前会话（默认 Process）
-Add-PathVar C:\tools -Prepend        # 放到最前
-Add-PathVar C:\tools -Scope User     # 持久化到用户级，并同步到当前会话
-Add-PathVar D:\lib -Name LIB -Scope Machine   # 系统级（需管理员）
-Remove-PathVar C:\tools              # 移除
-Get-PathVar                          # 列出 PATH，每行一条（可接管道过滤）
-Get-PathVar PSModulePath -Scope User # 列出指定变量、指定作用域
+Add-Path C:\tools                 # 追加到 PATH（默认变量），仅当前会话（默认 Process）
+Add-Path C:\tools -Prepend        # 放到最前
+Add-Path C:\tools -Scope User     # 持久化到用户级，并同步到当前会话
+Add-Path D:\lib -Name LIB -Scope Machine   # 系统级（需管理员）
+Remove-Path C:\tools              # 移除
+Get-Path                          # 列出 PATH，每行一条（可接管道过滤）
+Get-Path PSModulePath -Scope User # 列出指定变量、指定作用域
 ```
 
 - 默认变量为 `PATH`，默认作用域为 `Process`（只影响当前交互）。
 - 已存在的路径会**提示并忽略**（大小写、结尾斜杠不敏感）。
-- `Get-PathVar` 返回字符串数组，可 `Get-PathVar | Where-Object { ... }` 过滤。
+- `Get-Path` 返回字符串数组，可 `Get-Path | Where-Object { ... }` 过滤。
 
 ## 安装
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -123,10 +123,13 @@ Add-PathVar C:\tools -Prepend        # 放到最前
 Add-PathVar C:\tools -Scope User     # 持久化到用户级，并同步到当前会话
 Add-PathVar D:\lib -Name LIB -Scope Machine   # 系统级（需管理员）
 Remove-PathVar C:\tools              # 移除
+Get-PathVar                          # 列出 PATH，每行一条（可接管道过滤）
+Get-PathVar PSModulePath -Scope User # 列出指定变量、指定作用域
 ```
 
 - 默认变量为 `PATH`，默认作用域为 `Process`（只影响当前交互）。
 - 已存在的路径会**提示并忽略**（大小写、结尾斜杠不敏感）。
+- `Get-PathVar` 返回字符串数组，可 `Get-PathVar | Where-Object { ... }` 过滤。
 
 ## 安装
 

--- a/windows/powershell/install.ps1
+++ b/windows/powershell/install.ps1
@@ -1,9 +1,7 @@
-# Make the current user's PowerShell profile load the devenv git prompt.
-# Run once per PowerShell flavour (Windows PowerShell 5.1 and/or PowerShell 7),
-# because each one uses a different $PROFILE path. The change is idempotent.
-
-$promptScript = Join-Path $PSScriptRoot 'prompt.ps1'
-$sourceLine = ". '$promptScript'"
+# Make the current user's PowerShell profile load the devenv helpers
+# (prompt, path_manager, ...). Run once per PowerShell flavour (Windows
+# PowerShell 5.1 and/or PowerShell 7), because each uses a different $PROFILE
+# path. Every change is idempotent.
 
 $profilePath = $PROFILE.CurrentUserCurrentHost
 $profileDir = Split-Path $profilePath -Parent
@@ -11,10 +9,17 @@ if (-not (Test-Path $profileDir)) {
     New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
 }
 
-$existing = if (Test-Path $profilePath) { Get-Content $profilePath -Raw } else { '' }
-if ($existing -match [regex]::Escape($promptScript)) {
-    Write-Host "devenv prompt already installed in $profilePath"
-} else {
-    Add-Content -Path $profilePath -Value "`n# devenv: git-aware prompt`n$sourceLine"
-    Write-Host "Added devenv prompt to $profilePath"
+# Source every *.ps1 in this folder except the installer itself.
+$scripts = Get-ChildItem -Path $PSScriptRoot -Filter *.ps1 |
+    Where-Object { $_.Name -ne 'install.ps1' } |
+    Sort-Object Name
+
+foreach ($script in $scripts) {
+    $existing = if (Test-Path $profilePath) { Get-Content $profilePath -Raw } else { '' }
+    if ($existing -match [regex]::Escape($script.FullName)) {
+        Write-Host "Already installed: $($script.Name)"
+    } else {
+        Add-Content -Path $profilePath -Value "`n# devenv: $($script.BaseName)`n. '$($script.FullName)'"
+        Write-Host "Added $($script.Name) to $profilePath"
+    }
 }

--- a/windows/powershell/path_manager.ps1
+++ b/windows/powershell/path_manager.ps1
@@ -1,16 +1,16 @@
 # Manage ';' separated path variables such as PATH and PSModulePath.
 # PowerShell counterpart of shell/path_manager.
 #
-#   Add-PathVar C:\tools                       # append to PATH, current session
-#   Add-PathVar C:\tools -Prepend              # put it in front
-#   Add-PathVar C:\tools -Scope User           # persist for the user
-#   Add-PathVar D:\lib -Name LIB -Scope Machine
-#   Remove-PathVar C:\tools
-#   Get-PathVar                                # list PATH, one entry per line
+#   Add-Path C:\tools                       # append to PATH, current session
+#   Add-Path C:\tools -Prepend              # put it in front
+#   Add-Path C:\tools -Scope User           # persist for the user
+#   Add-Path D:\lib -Name LIB -Scope Machine
+#   Remove-Path C:\tools
+#   Get-Path                                # list PATH, one entry per line
 
 # List the entries of a path variable, one per line. The result is an array
 # of strings, so it also pipes into Where-Object / Select-String etc.
-function Get-PathVar {
+function Get-Path {
     [CmdletBinding()]
     param(
         [Parameter(Position = 0)]
@@ -26,8 +26,8 @@ function Get-PathVar {
     }
 }
 
-# Compare two path entries (case-insensitive, ignoring a trailing slash).
-function Test-PathVarContains {
+# Internal: does $Value already contain $Path? (case- and trailing-slash-insensitive)
+function _PathContains {
     param([string] $Value, [string] $Path)
     if (-not $Value) { return $false }
     $target = $Path.TrimEnd('\', '/')
@@ -37,15 +37,15 @@ function Test-PathVarContains {
     return $false
 }
 
-# Build the new value of a path variable after adding $Path (no dedup here).
-function Join-PathVar {
+# Internal: build the new value after adding $Path (no dedup here).
+function _JoinPath {
     param([string] $Current, [string] $Path, [switch] $Prepend)
     if (-not $Current) { return $Path }
     if ($Prepend) { return "$Path;$Current" }
     return "$Current;$Path"
 }
 
-function Add-PathVar {
+function Add-Path {
     [CmdletBinding()]
     param(
         # The path to add.
@@ -67,13 +67,13 @@ function Add-PathVar {
 
     $current = [Environment]::GetEnvironmentVariable($Name, $Scope)
 
-    if (Test-PathVarContains $current $Path) {
+    if (_PathContains $current $Path) {
         Write-Warning "'$Path' is already in $Name ($Scope); skipped."
         return
     }
 
     try {
-        [Environment]::SetEnvironmentVariable($Name, (Join-PathVar $current $Path -Prepend:$Prepend), $Scope)
+        [Environment]::SetEnvironmentVariable($Name, (_JoinPath $current $Path -Prepend:$Prepend), $Scope)
     } catch {
         Write-Error "Failed to set $Name at $Scope scope: $($_.Exception.Message)"
         return
@@ -83,13 +83,13 @@ function Add-PathVar {
     # the current process so it takes effect right away too.
     if ($Scope -ne 'Process') {
         $proc = [Environment]::GetEnvironmentVariable($Name, 'Process')
-        if (-not (Test-PathVarContains $proc $Path)) {
-            [Environment]::SetEnvironmentVariable($Name, (Join-PathVar $proc $Path -Prepend:$Prepend), 'Process')
+        if (-not (_PathContains $proc $Path)) {
+            [Environment]::SetEnvironmentVariable($Name, (_JoinPath $proc $Path -Prepend:$Prepend), 'Process')
         }
     }
 }
 
-function Remove-PathVar {
+function Remove-Path {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory, Position = 0)]

--- a/windows/powershell/path_manager.ps1
+++ b/windows/powershell/path_manager.ps1
@@ -1,0 +1,97 @@
+# Manage ';' separated path variables such as PATH and PSModulePath.
+# PowerShell counterpart of shell/path_manager.
+#
+#   Add-PathVar C:\tools                       # append to PATH, current session
+#   Add-PathVar C:\tools -Prepend              # put it in front
+#   Add-PathVar C:\tools -Scope User           # persist for the user
+#   Add-PathVar D:\lib -Name LIB -Scope Machine
+#   Remove-PathVar C:\tools
+
+# Compare two path entries (case-insensitive, ignoring a trailing slash).
+function Test-PathVarContains {
+    param([string] $Value, [string] $Path)
+    if (-not $Value) { return $false }
+    $target = $Path.TrimEnd('\', '/')
+    foreach ($entry in ($Value -split ';')) {
+        if ($entry -and $entry.TrimEnd('\', '/') -ieq $target) { return $true }
+    }
+    return $false
+}
+
+# Build the new value of a path variable after adding $Path (no dedup here).
+function Join-PathVar {
+    param([string] $Current, [string] $Path, [switch] $Prepend)
+    if (-not $Current) { return $Path }
+    if ($Prepend) { return "$Path;$Current" }
+    return "$Current;$Path"
+}
+
+function Add-PathVar {
+    [CmdletBinding()]
+    param(
+        # The path to add.
+        [Parameter(Mandatory, Position = 0)]
+        [string] $Path,
+
+        # The path variable to change, PATH by default.
+        [Parameter(Position = 1)]
+        [string] $Name = 'PATH',
+
+        # Put the path in front instead of appending.
+        [switch] $Prepend,
+
+        # Where the change applies. Process (current session) by default;
+        # User / Machine persist it (Machine needs administrator rights).
+        [ValidateSet('Process', 'User', 'Machine')]
+        [string] $Scope = 'Process'
+    )
+
+    $current = [Environment]::GetEnvironmentVariable($Name, $Scope)
+
+    if (Test-PathVarContains $current $Path) {
+        Write-Warning "'$Path' is already in $Name ($Scope); skipped."
+        return
+    }
+
+    try {
+        [Environment]::SetEnvironmentVariable($Name, (Join-PathVar $current $Path -Prepend:$Prepend), $Scope)
+    } catch {
+        Write-Error "Failed to set $Name at $Scope scope: $($_.Exception.Message)"
+        return
+    }
+
+    # A User/Machine change is invisible to the running shell; mirror it into
+    # the current process so it takes effect right away too.
+    if ($Scope -ne 'Process') {
+        $proc = [Environment]::GetEnvironmentVariable($Name, 'Process')
+        if (-not (Test-PathVarContains $proc $Path)) {
+            [Environment]::SetEnvironmentVariable($Name, (Join-PathVar $proc $Path -Prepend:$Prepend), 'Process')
+        }
+    }
+}
+
+function Remove-PathVar {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string] $Path,
+
+        [Parameter(Position = 1)]
+        [string] $Name = 'PATH',
+
+        [ValidateSet('Process', 'User', 'Machine')]
+        [string] $Scope = 'Process'
+    )
+
+    $target = $Path.TrimEnd('\', '/')
+    foreach ($s in @($Scope, 'Process' | Select-Object -Unique)) {
+        $current = [Environment]::GetEnvironmentVariable($Name, $s)
+        if (-not $current) { continue }
+        $kept = $current -split ';' | Where-Object { $_ -and $_.TrimEnd('\', '/') -ine $target }
+        try {
+            [Environment]::SetEnvironmentVariable($Name, ($kept -join ';'), $s)
+        } catch {
+            Write-Error "Failed to set $Name at $s scope: $($_.Exception.Message)"
+        }
+    }
+}

--- a/windows/powershell/path_manager.ps1
+++ b/windows/powershell/path_manager.ps1
@@ -6,6 +6,25 @@
 #   Add-PathVar C:\tools -Scope User           # persist for the user
 #   Add-PathVar D:\lib -Name LIB -Scope Machine
 #   Remove-PathVar C:\tools
+#   Get-PathVar                                # list PATH, one entry per line
+
+# List the entries of a path variable, one per line. The result is an array
+# of strings, so it also pipes into Where-Object / Select-String etc.
+function Get-PathVar {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [string] $Name = 'PATH',
+
+        [ValidateSet('Process', 'User', 'Machine')]
+        [string] $Scope = 'Process'
+    )
+
+    $value = [Environment]::GetEnvironmentVariable($Name, $Scope)
+    if ($value) {
+        $value -split ';' | Where-Object { $_ -ne '' }
+    }
+}
 
 # Compare two path entries (case-insensitive, ignoring a trailing slash).
 function Test-PathVarContains {


### PR DESCRIPTION
`shell/path_manager` 的 PowerShell 版,管理 `PATH` 这类以 `;` 分隔的路径变量。

## API 与行为

```powershell
Add-Path C:\tools                 # 追加到 PATH（默认变量），当前会话（默认 Process）
Add-Path C:\tools -Prepend        # 放最前
Add-Path C:\tools -Scope User     # 持久化到用户级，并同步进当前会话
Add-Path D:\lib -Name LIB -Scope Machine   # 系统级（需管理员）
Remove-Path C:\tools              # 移除
Get-Path                          # 列出 PATH，每行一条（返回字符串数组，可接管道）
```

- **默认变量 `PATH`、默认作用域 `Process`**（只影响当前交互）
- 追加为默认,`-Prepend` 放前面
- **已存在就提示并忽略**(大小写、结尾斜杠不敏感)
- `Scope` 支持 `Process/User/Machine`;`User/Machine` 持久化并镜像进当前会话立即生效

底层用内置 `[Environment]::Get/SetEnvironmentVariable` 与 `$env:`,封装去重+默认值+提示这一层。

## 命名

公开函数 `Add-Path` / `Remove-Path` / `Get-Path` 经实测在 PowerShell 7 与 Windows PowerShell 5.1 下**均无冲突**;内部 helper 用 `_PathContains` / `_JoinPath`(下划线前缀,对齐 POSIX 版 `_contains_path`),刻意避开内置的 `Join-Path` / `Test-Path` cmdlet。

## 安装器

`install.ps1` 改为自动 source `windows/powershell` 下所有 `*.ps1`(除自身),新增 helper 自动纳入,仍逐脚本幂等。

🤖 Generated with [Claude Code](https://claude.com/claude-code)