### PR TITLE
Add Authorize-SshKey.ps1 to authorize an SSH public key

### DIFF
--- a/windows/Authorize-SshKey.ps1
+++ b/windows/Authorize-SshKey.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+    Authorize an SSH public key for the current Windows user, picking the
+    correct authorized_keys location and ACL automatically.
+
+.DESCRIPTION
+    Windows OpenSSH reads keys differently depending on the account:
+      - members of Administrators: C:\ProgramData\ssh\administrators_authorized_keys
+        (must be readable only by Administrators and SYSTEM)
+      - normal users:              %USERPROFILE%\.ssh\authorized_keys
+
+    This is the way in when the account has no password, because Windows
+    blocks blank-password logons over the network, so password auth can
+    never succeed and key auth is the only option.
+
+    The script detects the account type from group membership (not from
+    whether the session is elevated) and installs the key idempotently.
+
+.PARAMETER PublicKey
+    The public key text, e.g. the contents of id_ed25519.pub.
+
+.PARAMETER Path
+    Read the public key from a file instead of passing it inline.
+
+.EXAMPLE
+    .\Authorize-SshKey.ps1 'ssh-ed25519 AAAA... user@mac'
+
+.EXAMPLE
+    .\Authorize-SshKey.ps1 -Path C:\Users\cf\mac.pub
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Text', Position = 0)]
+    [string] $PublicKey,
+
+    [Parameter(Mandatory, ParameterSetName = 'File')]
+    [string] $Path
+)
+
+if ($PSCmdlet.ParameterSetName -eq 'File') {
+    $PublicKey = Get-Content -Path $Path -Raw
+}
+$PublicKey = $PublicKey.Trim()
+if (-not $PublicKey) { throw 'The public key is empty.' }
+if ($PublicKey -notmatch '^(ssh-(rsa|ed25519|dss)|ecdsa-sha2-)') {
+    Write-Warning "This doesn't look like an OpenSSH public key; continuing anyway."
+}
+
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+$adminRole = [Security.Principal.WindowsBuiltInRole]::Administrator
+
+# Is the account a member of Administrators, independent of whether this
+# session is elevated? A UAC-filtered token drops the group from
+# $identity.Groups, so query the account membership directly instead.
+function Test-AdminMember {
+    $sid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+    try {
+        return (Get-LocalGroupMember -Group Administrators -ErrorAction Stop).SID.Value -contains $sid
+    } catch {
+        # Fallback: the Administrators SID is listed (as deny-only) even
+        # when un-elevated.
+        return [bool]((whoami /groups) | Select-String -SimpleMatch 'S-1-5-32-544')
+    }
+}
+$isAdminAccount = Test-AdminMember
+# Whether THIS session is elevated (needed to write under ProgramData).
+$isElevated = $principal.IsInRole($adminRole)
+
+if ($isAdminAccount) {
+    $authFile = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+    if (-not $isElevated) {
+        throw "'$($identity.Name)' is an administrator account, so the key must go in " +
+              "$authFile. Please re-run this script from an elevated PowerShell " +
+              "(Run as administrator)."
+    }
+} else {
+    $authFile = Join-Path $env:USERPROFILE '.ssh\authorized_keys'
+}
+
+$dir = Split-Path $authFile -Parent
+if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+# Idempotent: only append if this exact key is not already authorized.
+$existing = if (Test-Path $authFile) { Get-Content -Path $authFile } else { @() }
+if ($existing -contains $PublicKey) {
+    Write-Host "Key already authorized in $authFile"
+} else {
+    Add-Content -Path $authFile -Value $PublicKey -Encoding ascii
+    Write-Host "Added key to $authFile"
+}
+
+# The admin key file must be readable only by Administrators and SYSTEM,
+# otherwise sshd ignores it.
+if ($isAdminAccount) {
+    icacls $authFile /inheritance:r | Out-Null
+    icacls $authFile /grant 'Administrators:F' 'SYSTEM:F' | Out-Null
+    Write-Host 'ACL restricted to Administrators + SYSTEM.'
+}
+
+Write-Host "Done. Connect from the Mac with:  ssh $($env:USERNAME)@<this-host-ip>"

--- a/windows/README.md
+++ b/windows/README.md
@@ -131,6 +131,21 @@ Get-Path PSModulePath -Scope User # 列出指定变量、指定作用域
 - 已存在的路径会**提示并忽略**（大小写、结尾斜杠不敏感）。
 - `Get-Path` 返回字符串数组，可 `Get-Path | Where-Object { ... }` 过滤。
 
+### SSH 公钥授权
+
+让别的机器（如 Mac）用密钥免密登录本机的 OpenSSH。当 Windows 账户没设密码时尤其有用——Windows 禁止空密码账户走网络登录，密钥是唯一的路。[Authorize-SshKey.ps1](Authorize-SshKey.ps1) 会自动按账户类型选对位置和 ACL：
+
+```powershell
+# 管理员账户需在「管理员 PowerShell」里运行（写 C:\ProgramData\ssh）
+.\Authorize-SshKey.ps1 'ssh-ed25519 AAAA... user@mac'
+.\Authorize-SshKey.ps1 -Path C:\Users\cf\mac.pub
+```
+
+- 管理员账户 → `C:\ProgramData\ssh\administrators_authorized_keys`，并把 ACL 限制为 Administrators + SYSTEM。
+- 普通账户 → `%USERPROFILE%\.ssh\authorized_keys`。
+- 账户类型按**组成员身份**判断（不受是否提权影响），管理员账户在非提权窗口运行会提示需要提权，避免把公钥误写到读不到的位置。
+- 同一公钥重复授权会自动跳过。
+
 ## 安装
 
 ```console


### PR DESCRIPTION
让别的机器(如 Mac)用密钥免密登录本机 OpenSSH 的小工具。**账户没设密码时尤其有用**——Windows 禁止空密码账户走网络登录,密钥是唯一可行的路。

## 用法

```powershell
# 管理员账户需在「管理员 PowerShell」里运行
.\windows\Authorize-SshKey.ps1 'ssh-ed25519 AAAA... user@mac'
.\windows\Authorize-SshKey.ps1 -Path C:\Users\cf\mac.pub
```

## 行为

- **自动选位置**:管理员账户 → `C:\ProgramData\ssh\administrators_authorized_keys`(并把 ACL 限制为 Administrators + SYSTEM);普通账户 → `%USERPROFILE%\.ssh\authorized_keys`。
- **按组成员身份判断管理员,而非是否提权**:UAC 过滤后的 token 会丢掉 Administrators 组,若按 token 判断,管理员账户会被误判成普通账户、把公钥写到 `~\.ssh`——而 sshd 对管理员根本不读那里,导致登录失败。改用 `Get-LocalGroupMember`(后备 `whoami /groups`)直接查成员身份;管理员账户在非提权窗口运行会被要求提权。
- **幂等**:同一公钥重复授权自动跳过。

## 放置位置

放在 `windows/`(而非 `windows/powershell/`),因为 profile 安装器会 dot-source `windows/powershell/` 下所有 `*.ps1`——带 `Mandatory` 参数的脚本若被 source,会在每次开 shell 时弹参数提示。

## 验证

- 语法解析通过。
- 管理员账户(`cf`)在非提权会话运行:正确识别为管理员并抛错要求提权,**未**误写 `~\.ssh`(早期按 token 判断的版本会误写,已修正)。
- 同名公钥跳过逻辑、文件/目录创建均验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)