### PR TITLE
Add Install-SshServer.ps1 to install and enable sshd

### DIFF
--- a/windows/Install-SshServer.ps1
+++ b/windows/Install-SshServer.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Install and enable the Windows OpenSSH Server (sshd).
+
+.DESCRIPTION
+    Installs the OpenSSH.Server capability, starts sshd and sets it to start
+    automatically, opens the firewall on TCP 22, and optionally makes a chosen
+    shell (e.g. PowerShell 7) the default. Must be run from an elevated
+    PowerShell. Use Authorize-SshKey.ps1 afterwards to allow key-based login.
+
+.PARAMETER DefaultShell
+    Full path to the shell sshd should launch, e.g.
+    'C:\Program Files\PowerShell\7\pwsh.exe'. If omitted, the Windows default
+    (cmd.exe) is kept.
+
+.EXAMPLE
+    .\Install-SshServer.ps1
+
+.EXAMPLE
+    .\Install-SshServer.ps1 -DefaultShell 'C:\Program Files\PowerShell\7\pwsh.exe'
+#>
+[CmdletBinding()]
+param(
+    [string] $DefaultShell
+)
+
+$principal = [Security.Principal.WindowsPrincipal]::new(
+    [Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'This script must be run from an elevated PowerShell (Run as administrator).'
+}
+
+# 1) Install the OpenSSH server feature if it is not already present.
+$cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server*'
+if ($cap.State -ne 'Installed') {
+    Write-Host "Installing $($cap.Name) ..."
+    Add-WindowsCapability -Online -Name $cap.Name | Out-Null
+} else {
+    Write-Host 'OpenSSH.Server already installed.'
+}
+
+# 2) Start sshd now and on every boot.
+Set-Service -Name sshd -StartupType Automatic
+Start-Service sshd
+$svc = Get-Service sshd
+Write-Host "sshd is $($svc.Status), startup $($svc.StartType)."
+
+# 3) Allow inbound TCP 22 (the installer usually adds this; make sure).
+if (-not (Get-NetFirewallRule -Name 'sshd' -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' `
+        -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+    Write-Host 'Opened inbound TCP 22.'
+} else {
+    Write-Host 'Firewall rule for sshd already present.'
+}
+
+# 4) Optionally set the login shell (defaults to cmd.exe otherwise).
+if ($DefaultShell) {
+    if (-not (Test-Path $DefaultShell)) {
+        Write-Warning "DefaultShell not found: $DefaultShell"
+    }
+    if (-not (Test-Path 'HKLM:\SOFTWARE\OpenSSH')) {
+        New-Item -Path 'HKLM:\SOFTWARE\OpenSSH' -Force | Out-Null
+    }
+    New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell `
+        -Value $DefaultShell -PropertyType String -Force | Out-Null
+    Write-Host "Default shell set to $DefaultShell"
+}
+
+# Show the addresses a client (e.g. a Mac) can connect to.
+Write-Host ''
+Write-Host 'sshd ready. Connect with one of:'
+Get-NetIPAddress -AddressFamily IPv4 |
+    Where-Object { $_.IPAddress -ne '127.0.0.1' -and $_.IPAddress -notlike '169.*' } |
+    ForEach-Object { Write-Host "  ssh $env:USERNAME@$($_.IPAddress)" }
+Write-Host ''
+Write-Host 'Then authorize a key:  .\Authorize-SshKey.ps1 ''ssh-ed25519 AAAA... user@host'''

--- a/windows/README.md
+++ b/windows/README.md
@@ -131,9 +131,18 @@ Get-Path PSModulePath -Scope User # 列出指定变量、指定作用域
 - 已存在的路径会**提示并忽略**（大小写、结尾斜杠不敏感）。
 - `Get-Path` 返回字符串数组，可 `Get-Path | Where-Object { ... }` 过滤。
 
-### SSH 公钥授权
+### SSH 远程访问
 
-让别的机器（如 Mac）用密钥免密登录本机的 OpenSSH。当 Windows 账户没设密码时尤其有用——Windows 禁止空密码账户走网络登录，密钥是唯一的路。[Authorize-SshKey.ps1](Authorize-SshKey.ps1) 会自动按账户类型选对位置和 ACL：
+让别的机器（如 Mac）通过 OpenSSH 登录本机。先装服务端，再授权公钥。
+
+**安装并启用 sshd**（在「管理员 PowerShell」里运行）。[Install-SshServer.ps1](Install-SshServer.ps1) 装好 OpenSSH 服务端、设为开机自启、放行防火墙 22 端口，可选把默认 shell 设为 PowerShell 7：
+
+```powershell
+.\Install-SshServer.ps1
+.\Install-SshServer.ps1 -DefaultShell 'C:\Program Files\PowerShell\7\pwsh.exe'
+```
+
+**授权公钥**——当 Windows 账户没设密码时尤其有用（Windows 禁止空密码账户走网络登录，密钥是唯一的路）。[Authorize-SshKey.ps1](Authorize-SshKey.ps1) 会自动按账户类型选对位置和 ACL：
 
 ```powershell
 # 管理员账户需在「管理员 PowerShell」里运行（写 C:\ProgramData\ssh）


### PR DESCRIPTION
`Authorize-SshKey.ps1`(#19)的配套脚本:一键装好并启用 Windows OpenSSH 服务端,凑成完整一套远程访问工具。

## 用法(管理员 PowerShell)

```powershell
.\windows\Install-SshServer.ps1
.\windows\Install-SshServer.ps1 -DefaultShell 'C:\Program Files\PowerShell\7\pwsh.exe'
```

## 做了什么

1. 安装 `OpenSSH.Server` 功能(已装则跳过)
2. 启动 `sshd` 并设为开机自启
3. 放行防火墙入站 TCP 22(已有规则则跳过)
4. 可选:把 sshd 的默认登录 shell 设为指定路径(如 pwsh 7),否则保持 cmd
5. 最后打印可用的 `ssh 用户@IP` 连接地址,并提示下一步用 `Authorize-SshKey.ps1` 授权公钥

**需提权**,非管理员会话会直接抛错拒绝。

## 验证

语法解析通过;非提权运行被正确挡下(`This script must be run from an elevated PowerShell`)。功能本身需管理员实跑,留给使用时执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)